### PR TITLE
Add silenced npm alert ids to PFT project file

### DIFF
--- a/projectfiles/pressfreedomtracker.us.json
+++ b/projectfiles/pressfreedomtracker.us.json
@@ -1,5 +1,11 @@
 {
 	"variables": {
 		"SAFETY_IGNORE_IDS": ["41002", "51159"]
+	},
+	"npm": {
+		"silencedAlertIds": [
+			1088594,
+			1091147
+		]
 	}
 }


### PR DESCRIPTION
These are the only NPM audit alerts that are currently being silenced by the nightly checker.

Part of the larger process of centralizing the which NPM alerts are silenced.