### PR TITLE
Add `semver` ReDOS vulnerability GHSA-c2qf-rxjj-qqgw

### DIFF
--- a/audit-ci/freedom.press.json5
+++ b/audit-ci/freedom.press.json5
@@ -5,5 +5,6 @@
     // severe.
     "low": true,
     "allowlist": [
+        "GHSA-c2qf-rxjj-qqgw",
     ]
 }

--- a/audit-ci/pressfreedomtracker.us.json5
+++ b/audit-ci/pressfreedomtracker.us.json5
@@ -6,5 +6,6 @@
     "low": true,
     "allowlist": [
         "GHSA-36jr-mh4h-2g58",
+        "GHSA-c2qf-rxjj-qqgw",
     ]
 }

--- a/audit-ci/securedrop.org.json5
+++ b/audit-ci/securedrop.org.json5
@@ -5,5 +5,6 @@
 	// severe.
 	"low": true,
 	"allowlist": [
+		"GHSA-c2qf-rxjj-qqgw",
 	]
 }

--- a/audit-ci/wagtail-autocomplete.json5
+++ b/audit-ci/wagtail-autocomplete.json5
@@ -5,5 +5,6 @@
     // severe.
     "low": true,
     "allowlist": [
+        "GHSA-c2qf-rxjj-qqgw",
     ]
 }


### PR DESCRIPTION
This PR silences GHSA-c2qf-rxjj-qqgw across all the web repos.

Our semver dependency is via `babel` version 7, and the fix to update semver cannot be included in that version, see discussion:

https://github.com/babel/babel/pull/15722

Thus we cannot upgrade to fix it.  The same discussion reports:

> The good news is that Babel doesn't pass untrusted input to semver,
> so our usage is not affected by the reported CVE.

Meaning it's safe to do this.