### PR TITLE
freedom.press and pressfreedomtracker npm Allowlist update

### DIFF
--- a/audit-ci/freedom.press.json5
+++ b/audit-ci/freedom.press.json5
@@ -5,6 +5,6 @@
     // severe.
     "low": true,
     "allowlist": [
-        "GHSA-c2qf-rxjj-qqgw",
+        "GHSA-j8xg-fqg3-53r7|optionator>word-wrap",
     ]
 }

--- a/audit-ci/pressfreedomtracker.us.json5
+++ b/audit-ci/pressfreedomtracker.us.json5
@@ -6,6 +6,6 @@
     "low": true,
     "allowlist": [
         "GHSA-36jr-mh4h-2g58",
-        "GHSA-c2qf-rxjj-qqgw",
+        "GHSA-j8xg-fqg3-53r7|optionator>word-wrap"
     ]
 }


### PR DESCRIPTION
Remove semver vulnerability (it can be fixed on the site, now), add word-wrap (not able to be fixed, yet).