### PR TITLE
Add project json file for fpf-www-projects ignoring cryptography

### DIFF
--- a/projectfiles/fpf-www-projects.json
+++ b/projectfiles/fpf-www-projects.json
@@ -1,0 +1,7 @@
+{
+    "variables": {
+        "SAFETY_IGNORE_IDS": [
+            59062
+        ]
+    }
+}


### PR DESCRIPTION
Per web sync today, ignoring this for PytestInfra. I don't think there's a way to limit this ignore to *only* that directory, but that shouldn't be a problem.