### PR TITLE
Remove GHSA-c2qf-rxjj-qqgw from NPM allowlists

### DIFF
--- a/audit-ci/securedrop.org.json5
+++ b/audit-ci/securedrop.org.json5
@@ -5,6 +5,5 @@
 	// severe.
 	"low": true,
 	"allowlist": [
-		"GHSA-c2qf-rxjj-qqgw",
 	]
 }

--- a/audit-ci/wagtail-autocomplete.json5
+++ b/audit-ci/wagtail-autocomplete.json5
@@ -5,6 +5,5 @@
     // severe.
     "low": true,
     "allowlist": [
-        "GHSA-c2qf-rxjj-qqgw",
     ]
 }


### PR DESCRIPTION
This semver vulnerability has been fixed and the patched version added to wagtail-autocomplete and securedrop.org, so we do not need to allow it anymore.