### PR TITLE
Ignore vulnerability in Jinja2

### DIFF
--- a/projectfiles/pressfreedomtracker.us.json
+++ b/projectfiles/pressfreedomtracker.us.json
@@ -1,5 +1,5 @@
 {
 	"variables": {
-		"SAFETY_IGNORE_IDS": ["41002", "51159"]
+		"SAFETY_IGNORE_IDS": ["41002", "51159", "70612"]
 	}
 }


### PR DESCRIPTION
As mentioned in https://data.safetycli.com/v/70612/eda/, the maintainers believe that this is not a vulnerability. The vulnerability targets all versions of Jinja