### PR TITLE
Add unfixed vulnerability to freedom.press allowlist

### DIFF
--- a/audit-ci/freedom.press.json5
+++ b/audit-ci/freedom.press.json5
@@ -5,6 +5,6 @@
     // severe.
     "low": true,
     "allowlist": [
-
+		"GHSA-x3m3-4wpv-5vgc",  // dependency of modernizr, no fix available as of 2024-07-10
     ]
 }


### PR DESCRIPTION
Vulnerability in requirejs (a dependent of modernizr), GHSA-x3m3-4wpv-5vgc, is not fixed in any version. So we must add it to the allowlist for now.