### PR TITLE
Removes allowlist item for a dependency of modernizr

### DIFF
--- a/audit-ci/freedom.press.json5
+++ b/audit-ci/freedom.press.json5
@@ -5,6 +5,5 @@
     // severe.
     "low": true,
     "allowlist": [
-		"GHSA-x3m3-4wpv-5vgc",  // dependency of modernizr, no fix available as of 2024-07-10
     ]
 }


### PR DESCRIPTION
We're not using modernizr anymore in the freedom.press repo.